### PR TITLE
Resolved issue for Predefined parameter in url

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,20 +41,21 @@ module.exports = function (options) {
         // or double quote (") character followed by the URI itself, followed by an optional single quote (') or double quote (") character 
         // followed by optional white space followed by ')'. The two quote characters must be the same.
         // https://www.w3.org/TR/CSS2/syndata.html#uri
-
         cssFileContent = cssFileContent.replace(urlRegex, function (str, url) {
 
+            var queryParam = url.split('?');
             // remove white space
             url = url.replace(/\?[\s\S]*$/, "").trim();
             // remove single or double quote
             url = url.replace(/['"]*/g, "");
 
-
             if (url.indexOf("base64,") > -1 || url.indexOf("about:blank") > -1 || url.indexOf("http://") > -1 || url === '/') {
                 return str;
             }
-
-            return "url(" + url + "?" + parameterName + "=" + parameterValue + ")";
+            var queryString  = queryParam.length <2                ?
+                               "?" + parameterName + "=" + parameterValue :
+                               "?" + queryParam[1] + '&' + parameterName + "=" + parameterValue ;
+            return "url(" + url + queryString +")";
 
         });
 


### PR DESCRIPTION
Mateenpatel i was using your GulpCssImageCacheBurst Library and i found one issue in this for which i am raising this pull request. 

In my Css file there are some url which already have some parameter for example
https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i

So how it should behave like it should add the version in the end of this url but what it is was doing is it is replacing the family parameter and adding the url as follows:-

https://fonts.googleapis.com/css?v=1496843193929

So i made your code more flexible and now it can add the version in the end and shows url as 

https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i&v=1496843193929

